### PR TITLE
Better viewer

### DIFF
--- a/monitor/bin/run_monitor.sh
+++ b/monitor/bin/run_monitor.sh
@@ -17,17 +17,27 @@ source "$SCRIPT_DIR/../lib/http_check.sh"
 url_to_logfile() {
     local url="$1"
     local filename
+    local prefix=""
 
-    # Strip scheme (http:// or https://)
-    filename="${url#http://}"
-    filename="${filename#https://}"
+    # Detect scheme
+    if [[ "$url" == https://* ]]; then
+        prefix="s-"
+        filename="${url#https://}"
+    elif [[ "$url" == http://* ]]; then
+        filename="${url#http://}"
+    else
+        # No scheme (edge case)
+        filename="$url"
+    fi
 
-    # Replace dots with dashes and any remaining unsafe chars with underscores
+    # Replace dots with dashes
     filename="${filename//./-}"
+
+    # Replace remaining unsafe characters with underscores
     filename="$(echo "$filename" | sed 's|[:/?&=]|_|g')"
 
-    # Append .log
-    echo "$filename.log"
+    # Emit final filename
+    echo "${prefix}${filename}.log"
 }
 
 # Prepare log file and temp file

--- a/monitor/bin/run_monitor.sh
+++ b/monitor/bin/run_monitor.sh
@@ -13,15 +13,32 @@ SCRIPT_DIR=$(dirname "$0")
 source "$SCRIPT_DIR/../lib/logger.sh"
 source "$SCRIPT_DIR/../lib/http_check.sh"
 
-LOG_FILE="$SCRIPT_DIR/../logs/monitor.log"
-TEMP_LOG="$SCRIPT_DIR/../tmp/temp_headers.log"
+# Convert a URL into a safe log filename
+url_to_logfile() {
+    local url="$1"
+    local filename
 
+    # Strip scheme (http:// or https://)
+    filename="${url#http://}"
+    filename="${filename#https://}"
+
+    # Replace dots with dashes and any remaining unsafe chars with underscores
+    filename="${filename//./-}"
+    filename="$(echo "$filename" | sed 's|[:/?&=]|_|g')"
+
+    # Append .log
+    echo "$filename.log"
+}
+
+# Prepare log file and temp file
 URL="${1:-}"
+LOG_FILE="$SCRIPT_DIR/../logs/$(url_to_logfile "$URL")"
 
 if [[ -z "$URL" ]]; then
     echo "No URL provided"
     exit 1
 fi
 
+# Run the http check and log the output and cleanup the tmp file
 msg="$(check_url "$URL")"
 log_message "$msg"

--- a/monitor/bin/start_monitor.sh
+++ b/monitor/bin/start_monitor.sh
@@ -49,7 +49,7 @@ parse_urls "$URL_FILE" | while read -r url interval; do
     else
         echo "Adding cron job for $url (every $interval minutes)"
     fi
-
+    
     echo "$new_job" >> "$CRON_TMP"
 done
 

--- a/monitor/bin/start_monitor.sh
+++ b/monitor/bin/start_monitor.sh
@@ -50,6 +50,10 @@ parse_urls "$URL_FILE" | while read -r url interval; do
         echo "Adding cron job for $url (every $interval minutes)"
     fi
     
+    echo "Running a check..."
+    "$SCRIPT_DIR/run_monitor.sh" "$url"
+    echo "Check run complete. Cron job installed."
+
     echo "$new_job" >> "$CRON_TMP"
 done
 

--- a/monitor/bin/test.sh
+++ b/monitor/bin/test.sh
@@ -1,1 +1,0 @@
-crontab -r 

--- a/monitor/bin/watch_monitor.sh
+++ b/monitor/bin/watch_monitor.sh
@@ -27,6 +27,7 @@ fi
 for logfile in "${log_files[@]}"; do
     filename="$(basename "$logfile")"
 
+    echo -e "\n"
     echo "================================================================"
     echo " Site: $filename (5 most recent log entries)"
     echo "================================================================"
@@ -47,15 +48,27 @@ for logfile in "${log_files[@]}"; do
                     else if (key == "final_url")   final_url = value
                     else if (key == "final_status") status = value
                     else if (key == "latency")     latency = value
+                    else if (key == "redirect_statuses")     statuses = value
                 }
 
                 gsub("T", " at ", ts)
+                gsub(/[^|]*$/, "", statuses)
 
-                printf "%s %s -> %s %s in %s seconds\n",
-                       ts, url, final_url, status, latency
+                #printf "\n" ts "\n"
+                printf "\033[1m%s\033[0m\n", ts
+                #printf " \033[1;37;40m %s \033[0m", url
+                printf "\033[1;37;40m%s\033[0m", url
+                printf " -> " statuses
+                printf "\033[1;37;40m %s \033[0m\n", status
+                printf "  -> " final_url " in "
+                printf "\033[1m%s\033[0m", latency
+                printf " seconds\n"
+
+                #printf "%s \n %s \n   -> %s %s in %s seconds\n",
+                 #      ts, url, final_url, status, latency
             }
         '
-
+        
     echo
 done
 

--- a/monitor/bin/watch_monitor.sh
+++ b/monitor/bin/watch_monitor.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#######################################
+# UDAMonitor - Log Viewer
+# Human-friendly console output
+#######################################
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+LOG_DIR="$SCRIPT_DIR/../logs"
+LINES=5
+
+if [[ ! -d "$LOG_DIR" ]]; then
+    echo "Log directory not found: $LOG_DIR"
+    exit 1
+fi
+
+shopt -s nullglob
+log_files=("$LOG_DIR"/*.log)
+shopt -u nullglob
+
+if (( ${#log_files[@]} == 0 )); then
+    echo "No log files found."
+    exit 0
+fi
+
+for logfile in "${log_files[@]}"; do
+    filename="$(basename "$logfile")"
+
+    echo "================================================================"
+    echo " Site: $filename (5 most recent log entries)"
+    echo "================================================================"
+
+    tail -n "$LINES" "$logfile" \
+        | tr -d '\r' \
+        | awk '
+            {
+                ts = url = final_url = status = latency = "?"
+
+                for (i = 1; i <= NF; i++) {
+                    split($i, kv, "=")
+                    key = kv[1]
+                    value = substr($i, length(key) + 2)
+
+                    if (key == "timestamp")        ts = value
+                    else if (key == "url")         url = value
+                    else if (key == "final_url")   final_url = value
+                    else if (key == "final_status") status = value
+                    else if (key == "latency")     latency = value
+                }
+
+                gsub("T", " at ", ts)
+
+                printf "%s %s -> %s %s in %s seconds\n",
+                       ts, url, final_url, status, latency
+            }
+        '
+
+    echo
+done
+

--- a/monitor/bin/watch_monitor.sh
+++ b/monitor/bin/watch_monitor.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 #######################################
 # UDAMonitor - Log Viewer
 # Human-friendly console output
+# whipped together for fun
 #######################################
+
 
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 LOG_DIR="$SCRIPT_DIR/../logs"
@@ -24,10 +26,11 @@ if (( ${#log_files[@]} == 0 )); then
     exit 0
 fi
 
+echo -e "\n"
+
 for logfile in "${log_files[@]}"; do
     filename="$(basename "$logfile")"
 
-    echo -e "\n"
     echo "================================================================"
     echo " Site: $filename (5 most recent log entries)"
     echo "================================================================"
@@ -49,6 +52,7 @@ for logfile in "${log_files[@]}"; do
                     else if (key == "final_status") status = value
                     else if (key == "latency")     latency = value
                     else if (key == "redirect_statuses")     statuses = value
+                    else if (key == "err_msg")     err_msg = value
                 }
 
                 gsub("T", " at ", ts)
@@ -62,10 +66,8 @@ for logfile in "${log_files[@]}"; do
                 printf "\033[1;37;40m %s \033[0m\n", status
                 printf "  -> " final_url " in "
                 printf "\033[1m%s\033[0m", latency
-                printf " seconds\n"
+                printf " seconds " err_msg "\n"
 
-                #printf "%s \n %s \n   -> %s %s in %s seconds\n",
-                 #      ts, url, final_url, status, latency
             }
         '
         

--- a/monitor/config/urls.txt
+++ b/monitor/config/urls.txt
@@ -1,2 +1,4 @@
 http://google.com 2
 https://www.microsoft.com 3
+http://uusseekkllaajfjfj.com 2
+http://www.superuser.com/q/1471861/ 4

--- a/monitor/config/urls.txt
+++ b/monitor/config/urls.txt
@@ -1,2 +1,2 @@
 http://google.com 2
-https://www.microsoft.com 4
+https://www.microsoft.com 3

--- a/monitor/lib/http_check.sh
+++ b/monitor/lib/http_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # lib/http_check.sh
 
 #######################################
@@ -105,7 +105,7 @@ check_url() {
     #Echo in line-based key=value format
     echo "timestamp=$timestamp url=$url final_url=$final_url final_status=$final_status redirect_count=$redirect_count latency=$latency redirect_locations=$redirect_locations redirect_statuses=$redirect_statuses err_msg=$err_msg"
 
-    cleanup
+    #cleanup
 }
 
 

--- a/monitor/lib/http_check.sh
+++ b/monitor/lib/http_check.sh
@@ -5,6 +5,8 @@
 # Helpers
 #######################################
 
+TEMP_LOG="$SCRIPT_DIR/../tmp/temp_headers.log"
+
 fetch_headers() {
   curl -s -L -D "$TEMP_LOG" -o /dev/null "$1"
 }
@@ -23,11 +25,31 @@ extract_final_status() {
   extract_http_statuses | tail -n 1
 }
 
+extract_final_url() {
+  extract_redirect_locations | tail -n 1
+}
+
 count_redirects() {
   local total
   total="$(extract_http_statuses | wc -l)"
   echo $(( total - 1 ))  # subtract final response
 }
+
+# Builds arrays of redirect statuses and locations from the TEMP_LOG
+# Exports two global arrays: REDIRECT_STATUSES and REDIRECT_LOCATIONS
+build_redirects_array() {
+    REDIRECT_STATUSES=()
+    REDIRECT_LOCATIONS=()
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && REDIRECT_STATUSES+=("$line")
+    done < <(extract_http_statuses)
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && REDIRECT_LOCATIONS+=("$line")
+    done < <(extract_redirect_locations)
+}
+
 
 cleanup() {
   rm -f "$TEMP_LOG"
@@ -38,15 +60,43 @@ cleanup() {
 #######################################
 
 check_url() {
-    local url timestamp status redirects
-    url="$1"
-    timestamp="$(date +"%Y-%m-%d %H:%M:%S")"
+    local url="$1"
+    local timestamp
+    timestamp="$(date +"%Y-%m-%dT%H:%M:%S")"
 
-    fetch_headers "$url"
-    status="$(extract_final_status)"
-    redirects="$(count_redirects)"
+    # Temporary arrays for this check
+    local redirect_count final_status final_url err_msg
+    err_msg=""
 
-    echo "$timestamp | $url HTTP | $status | redirects=$redirects"
-    
-    #cleanup
+    # Try to fetch headers and follow redirects
+    if ! fetch_headers "$url"; then
+        err_msg="error=failed_to_fetch_headers"
+        final_status="N/A"
+        final_url="$url"
+    else
+        # Build arrays of redirect statuses and locations
+        build_redirects_array
+        redirect_count="$(count_redirects)"
+
+        if (( ${#REDIRECT_STATUSES[@]} > 0 )); then
+            final_status="$(extract_final_status)"
+        else
+            final_status="N/A"
+        fi
+
+        if (( ${#REDIRECT_LOCATIONS[@]} > 0 )); then
+            final_url="$(extract_final_url)"
+        else
+            final_url="$url"
+        fi
+
+    fi
+
+    # Echo in line-based key=value format
+    echo "timestamp=$timestamp url=$url final_url=$final_url final_status=$final_status redirect_count=$redirect_count ${err_msg}"
+
+    cleanup
 }
+
+
+

--- a/monitor/lib/http_check.sh
+++ b/monitor/lib/http_check.sh
@@ -8,7 +8,10 @@
 TEMP_LOG="$SCRIPT_DIR/../tmp/temp_headers.log"
 
 fetch_headers() {
-  curl -s -L -D "$TEMP_LOG" -o /dev/null "$1"
+    local url="$1"
+    # curl -s = silent, -L = follow redirects, -D = write headers to TEMP_LOG, -o /dev/null = discard body
+    # -w = write out total time (latency) at end
+    curl -s -L -D "$TEMP_LOG" -o /dev/null -w "%{time_total}" "$url"
 }
 
 extract_http_statuses() {
@@ -65,35 +68,42 @@ check_url() {
     timestamp="$(date +"%Y-%m-%dT%H:%M:%S")"
 
     # Temporary arrays for this check
-    local redirect_count final_status final_url err_msg
+    local redirect_count final_status final_url err_msg redirect_locations redirect_statuses delimiter
     err_msg=""
-
-    # Try to fetch headers and follow redirects
-    if ! fetch_headers "$url"; then
-        err_msg="error=failed_to_fetch_headers"
+    redirect_locations=""
+    redirect_statuses=""
+    delimiter="|"
+    
+    # Fetch headers and measure latency
+    latency=$(fetch_headers "$url") || {
+        err_msg="failed_to_fetch_headers"
         final_status="N/A"
         final_url="$url"
-    else
-        # Build arrays of redirect statuses and locations
-        build_redirects_array
+        redirect_count=0
+        latency="N/A"
+    }
+
+    # If fetch was successful, build redirect arrays
+    if [[ -z "$err_msg" ]]; then
+    
         redirect_count="$(count_redirects)"
+        final_status="$(extract_final_status)"
 
-        if (( ${#REDIRECT_STATUSES[@]} > 0 )); then
-            final_status="$(extract_final_status)"
-        else
-            final_status="N/A"
-        fi
-
+        build_redirects_array
+        
         if (( ${#REDIRECT_LOCATIONS[@]} > 0 )); then
             final_url="$(extract_final_url)"
+            redirect_locations=$(IFS="$delimiter"; echo "${REDIRECT_LOCATIONS[*]}")
+            redirect_statuses=$(IFS="$delimiter"; echo "${REDIRECT_STATUSES[*]}")
+
         else
             final_url="$url"
         fi
 
     fi
-
-    # Echo in line-based key=value format
-    echo "timestamp=$timestamp url=$url final_url=$final_url final_status=$final_status redirect_count=$redirect_count ${err_msg}"
+    
+    #Echo in line-based key=value format
+    echo "timestamp=$timestamp url=$url final_url=$final_url final_status=$final_status redirect_count=$redirect_count latency=$latency redirect_locations=$redirect_locations redirect_statuses=$redirect_statuses err_msg=$err_msg"
 
     cleanup
 }

--- a/monitor/lib/http_check.sh
+++ b/monitor/lib/http_check.sh
@@ -5,7 +5,7 @@
 # Helpers
 #######################################
 
-TEMP_LOG="$SCRIPT_DIR/../tmp/temp_headers.log"
+TEMP_LOG="$SCRIPT_DIR/../tmp/$RANDOM.log"
 
 fetch_headers() {
     local url="$1"

--- a/monitor/lib/logger.sh
+++ b/monitor/lib/logger.sh
@@ -3,5 +3,6 @@
 
 log_message() {
     local message="$1"
-      echo "$message" >> "$LOG_FILE"
+    clean_message="$(printf '%s\n' "$message" | tr -d '\r')"
+    echo "$clean_message" >> "$LOG_FILE"
 }

--- a/monitor/lib/logger.sh
+++ b/monitor/lib/logger.sh
@@ -3,5 +3,5 @@
 
 log_message() {
     local message="$1"
-      echo "$msg" >> "$LOG_FILE"
+      echo "$message" >> "$LOG_FILE"
 }

--- a/monitor/temp.log
+++ b/monitor/temp.log
@@ -1,0 +1,103 @@
+
+HTTP/1.1 302 Moved Temporarily
+Date: Fri, 06 Feb 2026 12:45:26 GMT
+Content-Type: text/html
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Expires: Thu, 01 Jan 1970 00:00:01 GMT
+Location: https://superuser.com/
+X-DNS-Prefetch-Control: off
+Server: cloudflare
+CF-RAY: 9c9abe9fdb54fa0f-ORD
+
+HTTP/2 200 
+date: Fri, 06 Feb 2026 12:45:27 GMT
+content-type: text/html; charset=utf-8
+server: cloudflare
+cf-ray: 9c9abea82d4151b7-ORD
+cf-cache-status: DYNAMIC
+cache-control: private
+set-cookie: prov=11ed4179-e055-45fa-8693-6fe0afdb611b; expires=Sat, 06 Feb 2027 12:45:27 GMT; domain=.superuser.com; path=/; secure; samesite=none; httponly
+set-cookie: __cflb=02DiuFRjcRKWq2brTwaTV6nhLcJ93oTcUrynaBTQVQzkC; SameSite=Lax; path=/; expires=Sat, 07-Feb-26 11:45:27 GMT; HttpOnly
+set-cookie: prov=11ed4179-e055-45fa-8693-6fe0afdb611b; Path=/; HttpOnly; Domain=superuser.com
+set-cookie: __cf_bm=CwpY44u3IhQMMlK3srYOFkDOWp79UQogSmgZaMfFsQs-1770381927-1.0.1.1-PhY26eY7K8fdwYm6q.sEg6MOQg0L2Yq3lg3fNTxg.hdVdJoQihEobKikZ2SdQ95Mv9e5nyPby4FwThICZ41Ua9kgkH4apmvR5_ntsgtXgPw; path=/; expires=Fri, 06-Feb-26 13:15:27 GMT; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+set-cookie: _cfuvid=u_5ROxFgI_wtJav5SQwkFEgrxKeEsf2epc_QSnf_cL0-1770381927805-0.0.1.1-604800000; path=/; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+strict-transport-security: max-age=31536000; includeSubDomains
+vary: Accept-Encoding
+content-security-policy: upgrade-insecure-requests; frame-ancestors 'self' https://stackexchange.com
+content-security-policy-report-only: default-src https: wss: data: blob: 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'; report-uri /_/csp-reports
+x-clacks-overhead: GNU Terry Pratchett
+x-frame-options: SAMEORIGIN
+x-request-guid: 0cc87a3a-cbf6-4b51-a965-78e7f8d0f2b8
+x-worker-origin-response-time: 82000000
+x-dns-prefetch-control: off
+
+HTTP/1.1 302 Moved Temporarily
+Date: Fri, 06 Feb 2026 12:46:09 GMT
+Content-Type: text/html
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Expires: Thu, 01 Jan 1970 00:00:01 GMT
+Location: https://superuser.com/
+X-DNS-Prefetch-Control: off
+Server: cloudflare
+CF-RAY: 9c9abfacad8783b9-ORD
+
+HTTP/2 200 
+date: Fri, 06 Feb 2026 12:46:10 GMT
+content-type: text/html; charset=utf-8
+server: cloudflare
+cf-ray: 9c9abfb3180deb68-ORD
+cf-cache-status: DYNAMIC
+cache-control: private
+set-cookie: prov=6afbff9a-7a2f-4f40-a14c-34ae348acb89; expires=Sat, 06 Feb 2027 12:46:10 GMT; domain=.superuser.com; path=/; secure; samesite=none; httponly
+set-cookie: __cflb=02DiuFRjcRKWq2brTwaTV6nhLcJ93oTcTnEK1ud59xCNY; SameSite=Lax; path=/; expires=Sat, 07-Feb-26 11:46:10 GMT; HttpOnly
+set-cookie: prov=6afbff9a-7a2f-4f40-a14c-34ae348acb89; Path=/; HttpOnly; Domain=superuser.com
+set-cookie: __cf_bm=UmVKCrLlmx1KUpUlo6ucgyyjxc6vJ4Uwdq3Dv.tKXgc-1770381970-1.0.1.1-9syhbdFcOF0ID7uiLs3UCTKLtrzCgwxuwkIWYE.AGNGXCud.DoGaQVle01Vo4G1jo5yQ7083Hgj5l0jHyx1o_M1Yzt5Kon17Ra6U_D9vhFM; path=/; expires=Fri, 06-Feb-26 13:16:10 GMT; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+set-cookie: _cfuvid=OaQCX6_oNbi6PV2q5akNMgCGJ7jn8XMAxwacZssXMKE-1770381970492-0.0.1.1-604800000; path=/; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+strict-transport-security: max-age=31536000; includeSubDomains
+vary: Accept-Encoding
+content-security-policy: upgrade-insecure-requests; frame-ancestors 'self' https://stackexchange.com
+content-security-policy-report-only: default-src https: wss: data: blob: 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'; report-uri /_/csp-reports
+x-clacks-overhead: GNU Terry Pratchett
+x-frame-options: SAMEORIGIN
+x-request-guid: 94678f29-fd2a-451d-a5df-33862d45c419
+x-worker-origin-response-time: 69000000
+x-dns-prefetch-control: off
+
+HTTP/1.1 302 Moved Temporarily
+Date: Fri, 06 Feb 2026 12:47:14 GMT
+Content-Type: text/html
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Expires: Thu, 01 Jan 1970 00:00:01 GMT
+Location: https://superuser.com/
+X-DNS-Prefetch-Control: off
+Server: cloudflare
+CF-RAY: 9c9ac140ddb8fa11-ORD
+
+HTTP/2 200 
+date: Fri, 06 Feb 2026 12:47:15 GMT
+content-type: text/html; charset=utf-8
+server: cloudflare
+cf-ray: 9c9ac1479d2c60b1-ORD
+cf-cache-status: DYNAMIC
+cache-control: private
+set-cookie: prov=85afe9c8-5b95-490d-ac66-26966a3a8916; expires=Sat, 06 Feb 2027 12:47:15 GMT; domain=.superuser.com; path=/; secure; samesite=none; httponly
+set-cookie: __cflb=02DiuFRjcRKWq2brTwaTV6nhLcJ93oTcUcDZrsDEoWLDS; SameSite=Lax; path=/; expires=Sat, 07-Feb-26 11:47:15 GMT; HttpOnly
+set-cookie: prov=85afe9c8-5b95-490d-ac66-26966a3a8916; Path=/; HttpOnly; Domain=superuser.com
+set-cookie: __cf_bm=uWjCHSSttdU5Ya29rGQOjROSk4HOM7GtY76d1lcNnt0-1770382035-1.0.1.1-_3a9fygyaprFcmLLodrJNIucksH1q4zySdbhfA_R.r3of.QrRNAWee9M.JyQWuTv5jMj1B_cXFruxF3WDswMfhpCxQOEzbBXopj252HzFgw; path=/; expires=Fri, 06-Feb-26 13:17:15 GMT; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+set-cookie: _cfuvid=rc.IcpscdpSqMETgvz5rUq91q4XiP6NU1cNZuSrrw2E-1770382035222-0.0.1.1-604800000; path=/; domain=.superuser.com; HttpOnly; Secure; SameSite=None
+strict-transport-security: max-age=31536000; includeSubDomains
+vary: Accept-Encoding
+content-security-policy: upgrade-insecure-requests; frame-ancestors 'self' https://stackexchange.com
+content-security-policy-report-only: default-src https: wss: data: blob: 'unsafe-eval' 'unsafe-inline'; frame-ancestors 'self'; report-uri /_/csp-reports
+x-clacks-overhead: GNU Terry Pratchett
+x-frame-options: SAMEORIGIN
+x-request-guid: 2b631827-3564-4ffd-83eb-14430965d940
+x-worker-origin-response-time: 72000000
+x-dns-prefetch-control: off
+


### PR DESCRIPTION
Summary

This PR refactors the logging model to store logs per monitored website instead of using a single central log file. It also introduces a console-based log viewer that allows users to easily inspect logs for individual sites.

What changed

Log output is now written to separate log files per website
Improves readability and traceability
Makes per-site troubleshooting significantly easier
Added a Bash-based console viewer
Allows users to list and view logs for specific websites
Designed to work cleanly with existing cron-based execution
Existing cron jobs and monitoring logic remain unchanged aside from log routing

Why this change

The single log file became increasingly difficult to work with as the number of monitored sites grew. Splitting logs by website:
Reduces noise when debugging failures or latency spikes
Aligns better with future plans for scaling, automation, and deployment
Lays groundwork for eventual migration to EC2 and potential refactors (e.g., Python, Docker)

Scope and compatibility
No breaking changes to existing cron schedules
Log format remains consistent; only file organization has changed
Fully implemented in Bash to match the current codebase

Follow-up work
Update documentation (README, changelog, wiki) to reflect new logging behavior
Infrastructure and deployment work (Terraform / EC2) will be handled in separate PRs